### PR TITLE
feat: print error not fix msg

### DIFF
--- a/internal/exchange/marketdata.go
+++ b/internal/exchange/marketdata.go
@@ -245,7 +245,7 @@ func startMarketData() {
 
 	props, err := NewProperties("configs/got_settings")
 	if err != nil {
-		panic("unable to read multicast addr")
+		panic(err)
 	}
 	saddr := props.GetString("multicast_addr", "")
 	if saddr == "" {


### PR DESCRIPTION
I just noticed that this error can sometimes help fix an issue if you are running the executable from the wrong path.

An error here is not always due to "unable to read multicast addr".