### PR TITLE
add some docs and correct improve error print

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,16 @@ localhost:8080/api/stats/SYMBOL
 ![client screen shot](doc/clientss.png)
 ![web screen shot](doc/webss.png)
 ![lit screen shot](doc/litss.png)
+
+# Common issues
+
+## Error: `route ip+net: no such network interface`
+
+This error is most likely caused because `got_settings` is configured by default as `multicast_intf=lo0`.
+
+The lo0 interface is a loopback interface on Unix-based systems, but it might not be named lo0 on all systems. On Linux, it's usually named lo. On macOS and some BSD systems, it might be named lo0.
+
+Ensure that the lo0 interface exists on your system. You can list network interfaces using:
+
+- Linux/macOS: `ifconfig` or `ip a`
+- Windows: `ipconfig /all`

--- a/internal/exchange/marketdata.go
+++ b/internal/exchange/marketdata.go
@@ -257,7 +257,7 @@ func startMarketData() {
 	}
 	_intf, err := net.InterfaceByName(intf)
 	if err != nil {
-		panic("unable to read multicast interface")
+		panic(err)
 	}
 
 	fmt.Println("publishing marketdata at", saddr)


### PR DESCRIPTION
When running exchange executable in a docker container we get:

```
panic: route ip+net: no such network interface

goroutine 1 [running]:
github.com/robaho/go-trader/internal/exchange.startMarketData()
        /app/internal/exchange/marketdata.go:261 +0x336
github.com/robaho/go-trader/internal/exchange.(*exchange).Start(...)
        /app/internal/exchange/exchange.go:284
main.main()
        /app/cmd/exchange/main.go:69 +0x517
```


This is due to lo0 not being available. 